### PR TITLE
Fix error: UnicodeDecodeError

### DIFF
--- a/UriDeep.py
+++ b/UriDeep.py
@@ -115,7 +115,7 @@ def read_domain(domain):
 
 def read_confusables(filename):
     lines, confusables = [], {}
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         lines = f.readlines()
     for line in lines:
         characters = list(line.replace('\n', ''))


### PR DESCRIPTION
Great tool!

I was having a small error when running it from master, so here you have a small PR to fix it.

The error was: `UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 7: character maps to <undefined>`